### PR TITLE
Campaign cloning issues

### DIFF
--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -128,8 +128,9 @@ class Campaign extends FormEntity
      */
     public function __clone()
     {
-        $this->leads = new ArrayCollection();
-        $this->id    = null;
+        $this->leads  = new ArrayCollection();
+        $this->events = new ArrayCollection();
+        $this->id     = null;
 
         parent::__clone();
     }

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -167,6 +167,16 @@ class Event
     }
 
     /**
+     * Clean up after clone
+     */
+    public function __clone()
+    {
+        $this->id       = null;
+        $this->tempId   = null;
+        $this->campaign = null;
+    }
+
+    /**
      * @param string $prop
      * @param mixed  $val
      *


### PR DESCRIPTION
**Description**

1) The cloned events needed to have their IDs prefixed with 'new' so that the model functions treat them as new and rebuild the canvasSettings.
2) Controller method getSessionSources() assumed that lead sources were already persisted and thus did not persist again if nothing had changed.  Had to tell it if the campaign was a clone so that it forces the saving of the lead sources.
3) Prevented the calling of lockEntity and unlockEntity methods which prematurely persisted the cloned campaign to the database.
4) Fixed the cancel button to return to index instead of view for clones since campaign doesn't exist to view.
