### PR TITLE
Reversed the query to prevent double executing events

### DIFF
--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -352,7 +352,7 @@ class EventRepository extends CommonRepository
      *
      * @return array
      */
-    public function getEventLog($campaignId, $leads = array(), $havingEvents = array(), $excludeEvents = array(), $notInEvents = array())
+    public function getEventLog($campaignId, $leads = array(), $havingEvents = array(), $excludeEvents = array())
     {
         $q = $this->_em->getConnection()->createQueryBuilder();
 
@@ -399,12 +399,6 @@ class EventRepository extends CommonRepository
             );
         }
 
-        if (!empty($notInEvents)) {
-            $q->andWhere(
-                $q->expr()->notIn('e.event_id', $notInEvents)
-            );
-        }
-var_dump($notInEvents, $q->getSql());
         $results = $q->execute()->fetchAll();
 
         $log = array();

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -1027,13 +1027,13 @@ class EventModel extends CommonFormModel
                         $leadLog = $repo->getEventLog($campaignId, $campaignLeads, array($grandParentId), array_keys($events));
                         $applicableLeads = array_keys($leadLog);
                     } else {
-                        $notInEvents = array_keys($events);
-                        $notInEvents[] = $campaignEvents[$parentId]['id'];
-                        $leadLog = $repo->getEventLog($campaignId, $campaignLeads, array(), array(), $notInEvents);
+                        // The event has no grandparent (likely because the decision is first in the campaign) so find leads that HAVE
+                        // already executed the "non-action" events then exclude them
+                        $leadLog           = $repo->getEventLog($campaignId, $campaignLeads, array_keys($events));
                         $unapplicableLeads = array_keys($leadLog);
 
-                        // Get unique values from both arrays
-                        $applicableLeads = array_merge(array_diff($unapplicableLeads, $campaignLeads), array_diff($campaignLeads, $unapplicableLeads));
+                        // Only use apply to leads that are not applicable
+                        $applicableLeads = array_diff($campaignLeads, $unapplicableLeads);
                     }
 
                     if (empty($applicableLeads)) {


### PR DESCRIPTION
Instead of excluding the events, I think we need to include them them filter out the leads that have already executed them. See what you think.
