### PR TITLE
Fixes detecting the form type

### DIFF
--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -25,11 +25,12 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/segments/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $id             = $response['segment']['id'];
 
         if (!empty($response['errors'][0])) {
             $this->fail($response['errors'][0]['code'].': '.$response['errors'][0]['message']);
         }
+
+        $this->assertTrue(!empty($response['list']['id']));
 
         // $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
         // $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);


### PR DESCRIPTION
The form type is wrapped by OrderedResolvedFormType so the FQCN was not correctly determined which means API fields were not processed correctly. This fixes that by getting the real type from the proxied form type. 