### PR TITLE
Fix get choices for radio group

### DIFF
--- a/app/bundles/FormBundle/Helper/PropertiesAccessor.php
+++ b/app/bundles/FormBundle/Helper/PropertiesAccessor.php
@@ -49,7 +49,7 @@ class PropertiesAccessor
         $choices = [];
 
         if (is_array($options) && !isset($options[0]['value'])) {
-            return $options;
+            return array_flip($options);
         }
 
         if (!is_array($options)) {

--- a/app/bundles/FormBundle/Tests/Helper/PropertiesAccessorTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/PropertiesAccessorTest.php
@@ -134,7 +134,7 @@ final class PropertiesAccessorTest extends \PHPUnit\Framework\TestCase
         $options = ['choice_a' => 'Choice A'];
 
         $this->assertSame(
-            $options,
+            array_flip($options),
             $this->propertiesAccessor->getChoices($options)
         );
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If we use radio group, child field display wrong values of parent field

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create radio group with label/value : First/1, Second/2
2. Create child text field 
3. Try choose in second tab Condition values - you are able to choose flipped values
4. After fix should works properly.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
