### PR TITLE
mb_convert_encoding(): Handling HTML entities via mbstring is deprecated

### DIFF
--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -225,7 +225,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
         $dom     = new \DOMDocument('1.0', 'utf-8');
 
-        $dom->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_NOERROR);
+        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
         $tbody = $dom->getElementById('reportTable')->getElementsByTagName('tbody')[0];
         $rows  = $tbody->getElementsByTagName('tr');
 


### PR DESCRIPTION
Use mb_encode_numericentity instead.
